### PR TITLE
requirements for singer-python >=5.4.1,<6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     classifiers=["Programming Language :: Python :: 3 :: Only"],
     py_modules=["singer_discover"],
     install_requires=[
-        "singer-python==5.4.1",
+        "singer-python>=5.4.1,<6.0",
         "PyInquirer==1.0.3"
     ],
     entry_points="""


### PR DESCRIPTION
Fixes #2 

Should allow people to install this fantastic tool next to `taps` that have a version that is newer than `5.4.1`.