### PR TITLE
Adding feature to sort fields so they show up in alphabetical order.

### DIFF
--- a/singer_discover/__init__.py
+++ b/singer_discover/__init__.py
@@ -89,6 +89,12 @@ def main():
                         'disabled': disabled
                     })
 
+            # Order fields alphabetically, skip if error
+            try:
+                fields = sorted(fields, key=lambda field: field['name'])
+            except KeyError:
+                pass
+
             stream_options = {
                 'type': 'checkbox',
                 'message': 'Select fields from stream: `{}`'.format(


### PR DESCRIPTION
Adding feature to display fields from each stream in alphabetical order (A-Z). This is especially useful for streams that have 50+ fields where the random ordering makes it hard to find the exact fields desired for selection.